### PR TITLE
Fixes an issue where an input with type=date is being parsed as a float.

### DIFF
--- a/src/FormBase.js
+++ b/src/FormBase.js
@@ -152,6 +152,8 @@ export default class FormBase extends React.Component {
             }
           } else if (json.value === 'null') {
             val = null;
+          } else if (node.elements[i].type === 'date') {
+            val = json.value;
           } else if (/^[0-9.]+/.test(json.value)) {
             val = parseFloat(json.value);
           } else {


### PR DESCRIPTION
I was having an issue where inputting a valid ISO formatted date such as 2015-06-25 into an input field was being serialized to a number. This library is great for building a form that, when serialize(), is called, generates an object matching what an API expects, so it would be great if there were a way to have serialize preserve dates so that the user doesn't need to do any post-processing to fix those fields.

I can't think of any reason why if someone set type="date" on their input field, they would want it to be sent to parseFloat(), so I think this change makes sense.