### PR TITLE
Radio input value serializing does not deliver selected value

### DIFF
--- a/src/FormBase.js
+++ b/src/FormBase.js
@@ -119,6 +119,7 @@ export default class FormBase extends React.Component {
     let json;
     let val;
     let len = node.elements.length;
+    let ignoreValue = false;
 
     // This will iterate through the form object that Qs creates and de-cache
     // each value.
@@ -144,7 +145,9 @@ export default class FormBase extends React.Component {
         } else {
           valCache[val] = json.value;
         }
-        queryStr = queryStr + '&' + json.name + '=' + encodeURIComponent(val);
+        if (!ignoreValue) {
+          queryStr = queryStr + '&' + json.name + '=' + encodeURIComponent(val);
+        }
       }
     }
     data = Qs.parse(queryStr, {

--- a/src/FormBase.js
+++ b/src/FormBase.js
@@ -138,10 +138,17 @@ export default class FormBase extends React.Component {
     // type of input that shouldn't be serialized.
     for (let i = 0; i < len; i++) {
       if (typeof node.elements[i].getAttribute('data-serial') === 'string') {
+        ignoreValue = false;
         json = JSON.parse(node.elements[i].getAttribute('data-serial'));
         val = CACHE_KEY + i;
         if (node.elements[i].type === 'file' && node.elements[i].value) {
           valCache[val] = node.elements[i].files;
+        } else if (node.elements[i].type === 'radio') {
+          if (node.elements[i].checked) {
+            valCache[val] = json.value;
+          } else {
+            ignoreValue = true;
+          }
         } else {
           valCache[val] = json.value;
         }


### PR DESCRIPTION
For radio inputs all values of the inputs are returned on serialization. There is no indication which radio button is selected by the user. This pull request only serializes the checked radio value.

The issue is reproducable on the demo page, click a radio button and the serialize shows:
`"radioexample": [
    "radio-test-1",
    "radio-test-2",
    "radio-test-3",
    "radio-test-4"
 ],`

The PR changes this to: `“radioexample” : “radio-test-3”`